### PR TITLE
Feature 1992: add Support for compose @Preview 

### DIFF
--- a/metadata/src/main/java/com/infinum/arkive/metadata/JsonUtils.kt
+++ b/metadata/src/main/java/com/infinum/arkive/metadata/JsonUtils.kt
@@ -1,4 +1,4 @@
-package com.inifnum.arkive.metadata
+package com.infinum.arkive.metadata
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json

--- a/metadata/src/main/java/com/infinum/arkive/metadata/model/ArkiveShowcase.kt
+++ b/metadata/src/main/java/com/infinum/arkive/metadata/model/ArkiveShowcase.kt
@@ -1,4 +1,4 @@
-package com.inifnum.arkive.metadata.model
+package com.infinum.arkive.metadata.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/metadata/src/main/java/com/infinum/arkive/metadata/model/ComponentsMetaData.kt
+++ b/metadata/src/main/java/com/infinum/arkive/metadata/model/ComponentsMetaData.kt
@@ -1,4 +1,4 @@
-package com.inifnum.arkive.metadata.model
+package com.infinum.arkive.metadata.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/plugin/src/main/java/com/infinum/arkive/plugin/generators/ShowcaseGenerator.kt
+++ b/plugin/src/main/java/com/infinum/arkive/plugin/generators/ShowcaseGenerator.kt
@@ -1,8 +1,8 @@
 package com.infinum.arkive.plugin.generators
 
-import com.inifnum.arkive.metadata.model.ArkiveShowcase
-import com.inifnum.arkive.metadata.model.ComponentsMetaData
-import com.inifnum.arkive.metadata.model.ShowcaseItem
+import com.infinum.arkive.metadata.model.ArkiveShowcase
+import com.infinum.arkive.metadata.model.ComponentsMetaData
+import com.infinum.arkive.metadata.model.ShowcaseItem
 
 interface ShowcaseGenerator {
     fun generateShowcase(snapshots: List<String>, metadata: ComponentsMetaData): ArkiveShowcase

--- a/plugin/src/main/java/com/infinum/arkive/plugin/services/MetadataLoader.kt
+++ b/plugin/src/main/java/com/infinum/arkive/plugin/services/MetadataLoader.kt
@@ -1,7 +1,7 @@
 package com.infinum.arkive.plugin.services
 
-import com.inifnum.arkive.metadata.fromJson
-import com.inifnum.arkive.metadata.model.ComponentsMetaData
+import com.infinum.arkive.metadata.fromJson
+import com.infinum.arkive.metadata.model.ComponentsMetaData
 import java.io.File
 import org.gradle.api.Project
 

--- a/plugin/src/main/java/com/infinum/arkive/plugin/writers/ShowcaseWriter.kt
+++ b/plugin/src/main/java/com/infinum/arkive/plugin/writers/ShowcaseWriter.kt
@@ -1,7 +1,7 @@
 package com.infinum.arkive.plugin.writers
 
-import com.inifnum.arkive.metadata.model.ArkiveShowcase
-import com.inifnum.arkive.metadata.toJson
+import com.infinum.arkive.metadata.model.ArkiveShowcase
+import com.infinum.arkive.metadata.toJson
 import java.io.File
 
 interface ShowcaseWriter {

--- a/processor/src/main/java/com/infinum/arkive/processor/ArkiveProcessor.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/ArkiveProcessor.kt
@@ -7,11 +7,13 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.infinum.arkive.processor.models.ArkiveOptions
 import com.infinum.arkive.processor.subprocessors.ComposeSubprocessor
 
 class ArkiveProcessor(
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
+    private val options: ArkiveOptions
 ) : SymbolProcessor {
     private var processed = false
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -20,7 +22,7 @@ class ArkiveProcessor(
         }
         processed = true
 
-        ComposeSubprocessor().process(resolver, codeGenerator, logger)
+        ComposeSubprocessor().process(resolver, codeGenerator, logger, options)
         return emptyList()
     }
 }
@@ -28,6 +30,9 @@ class ArkiveProcessor(
 class ArkiveProcessorProvider : SymbolProcessorProvider {
     override fun create(
         environment: SymbolProcessorEnvironment,
-    ): SymbolProcessor = ArkiveProcessor(environment.codeGenerator, environment.logger)
-
+    ): SymbolProcessor {
+        val skipPreviews: Boolean = environment.options["skipPreviews"]?.toBooleanStrict() ?: false
+        val options = ArkiveOptions(skipPreviews)
+        return ArkiveProcessor(environment.codeGenerator, environment.logger, options)
+    }
 }

--- a/processor/src/main/java/com/infinum/arkive/processor/ArkiveProcessor.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/ArkiveProcessor.kt
@@ -13,7 +13,7 @@ import com.infinum.arkive.processor.subprocessors.ComposeSubprocessor
 class ArkiveProcessor(
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
-    private val options: ArkiveOptions
+    private val options: ArkiveOptions,
 ) : SymbolProcessor {
     private var processed = false
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/processor/src/main/java/com/infinum/arkive/processor/collectors/ArkiveComposableCollector.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/collectors/ArkiveComposableCollector.kt
@@ -33,7 +33,9 @@ class ArkiveComposableCollector(
                     parameters = it.parameters,
                 )
             }
-            .toSet()
+            .toSet().also {
+                logger.info("Collected ${it.size} @ArkiveComposable")
+            }
     }
 
     companion object {

--- a/processor/src/main/java/com/infinum/arkive/processor/collectors/PreviewCollector.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/collectors/PreviewCollector.kt
@@ -1,6 +1,5 @@
 package com.infinum.arkive.processor.collectors
 
-import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -12,7 +11,7 @@ class PreviewCollector(
     private val logger: KSPLogger,
 ) : Collector<ComposeHolder> {
 
-    @OptIn(KspExperimental::class)
+    @Suppress("LabeledExpression")
     override fun collect(): Set<ComposeHolder> {
         return resolver.getSymbolsWithAnnotation(COMPOSABLE_ANNOTATION)
             .filterIsInstance<KSFunctionDeclaration>()
@@ -33,7 +32,9 @@ class PreviewCollector(
                     parameters = it.parameters,
                 )
             }
-            .toSet()
+            .toSet().also {
+                logger.info("Collected ${it.size} @Previews")
+            }
     }
 
     private fun KSFunctionDeclaration.getMainPreviewAnnotation(): KSAnnotation? =

--- a/processor/src/main/java/com/infinum/arkive/processor/collectors/PreviewCollector.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/collectors/PreviewCollector.kt
@@ -1,0 +1,59 @@
+package com.infinum.arkive.processor.collectors
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.infinum.arkive.processor.models.ComposeHolder
+
+class PreviewCollector(
+    private val resolver: Resolver,
+    private val logger: KSPLogger,
+) : Collector<ComposeHolder> {
+
+    @OptIn(KspExperimental::class)
+    override fun collect(): Set<ComposeHolder> {
+        return resolver.getSymbolsWithAnnotation(COMPOSABLE_ANNOTATION)
+            .filterIsInstance<KSFunctionDeclaration>()
+            .mapNotNull {
+                val previewAnnotation = it.getMainPreviewAnnotation()
+                    ?: it.getVariantsAnnotation()
+                    ?: return@mapNotNull null
+
+                ComposeHolder(
+                    function = it,
+                    functionName = it.simpleName.getShortName(),
+                    name = previewAnnotation.getStringArgument("name").orEmpty(),
+                    group = previewAnnotation.getStringArgument("group").orEmpty(),
+                    skip = false,
+                    tags = emptyList(),
+                    extraMetadata = emptyList(),
+                    packageName = it.packageName.asString(),
+                    parameters = it.parameters,
+                )
+            }
+            .toSet()
+    }
+
+    private fun KSFunctionDeclaration.getMainPreviewAnnotation(): KSAnnotation? =
+        annotations.firstOrNull { annotation -> annotation.shortName.getShortName() == PREVIEW_ANNOTATION_NAME }
+
+    private fun KSFunctionDeclaration.getVariantsAnnotation(): KSAnnotation? {
+        return annotations.firstOrNull { annotation ->
+            annotation.shortName.getShortName().startsWith(PREVIEW_ANNOTATION_NAME)
+        }
+    }
+
+    private fun KSAnnotation.getStringArgument(name: String): String? {
+        return arguments
+            .firstOrNull { arg ->
+                arg.name?.getShortName() == name
+            }?.value as? String
+    }
+
+    companion object {
+        const val COMPOSABLE_ANNOTATION = "androidx.compose.runtime.Composable"
+        const val PREVIEW_ANNOTATION_NAME = "Preview"
+    }
+}

--- a/processor/src/main/java/com/infinum/arkive/processor/models/ArkiveOptions.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/models/ArkiveOptions.kt
@@ -1,5 +1,5 @@
 package com.infinum.arkive.processor.models
 
 data class ArkiveOptions(
-    val skipPreviews: Boolean
+    val skipPreviews: Boolean,
 )

--- a/processor/src/main/java/com/infinum/arkive/processor/models/ArkiveOptions.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/models/ArkiveOptions.kt
@@ -1,0 +1,5 @@
+package com.infinum.arkive.processor.models
+
+data class ArkiveOptions(
+    val skipPreviews: Boolean
+)

--- a/processor/src/main/java/com/infinum/arkive/processor/models/ComposeHolder.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/models/ComposeHolder.kt
@@ -31,8 +31,5 @@ data class ComposeHolder(
         return functionId == other.functionId
     }
 
-    override fun hashCode(): Int {
-        return functionId.hashCode()
-    }
-
+    override fun hashCode(): Int = functionId.hashCode()
 }

--- a/processor/src/main/java/com/infinum/arkive/processor/models/ComposeHolder.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/models/ComposeHolder.kt
@@ -20,4 +20,19 @@ data class ComposeHolder(
             val validPackageName = packageName.replace(".", "_")
             return "${validPackageName}_$functionName".lowercase()
         }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (other !is ComposeHolder) {
+            return false
+        }
+        return functionId == other.functionId
+    }
+
+    override fun hashCode(): Int {
+        return functionId.hashCode()
+    }
+
 }

--- a/processor/src/main/java/com/infinum/arkive/processor/specs/ComposeMetaDataSpec.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/specs/ComposeMetaDataSpec.kt
@@ -2,10 +2,10 @@ package com.infinum.arkive.processor.specs
 
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
+import com.infinum.arkive.metadata.model.Component
+import com.infinum.arkive.metadata.model.ComponentsMetaData
+import com.infinum.arkive.metadata.toJson
 import com.infinum.arkive.processor.models.ComposeHolder
-import com.inifnum.arkive.metadata.model.Component
-import com.inifnum.arkive.metadata.model.ComponentsMetaData
-import com.inifnum.arkive.metadata.toJson
 import java.io.File
 
 class ComposeMetaDataSpec(

--- a/processor/src/main/java/com/infinum/arkive/processor/specs/ComposeSpec.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/specs/ComposeSpec.kt
@@ -32,6 +32,8 @@ class ComposeSpec(
                 codeGenerator = codeGenerator,
                 aggregating = false,
             )
+
+        logger.info("Generated $SIMPLE_NAME")
     }
 
     override fun getFileSpec(): FileSpec.Builder {

--- a/processor/src/main/java/com/infinum/arkive/processor/subprocessors/ComposeSubprocessor.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/subprocessors/ComposeSubprocessor.kt
@@ -4,16 +4,23 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.infinum.arkive.processor.collectors.ArkiveComposableCollector
+import com.infinum.arkive.processor.collectors.PreviewCollector
 import com.infinum.arkive.processor.specs.ComposeMetaDataSpec
 import com.infinum.arkive.processor.specs.ComposeSpec
 import com.infinum.arkive.processor.validators.ComposeValidator
 
 class ComposeSubprocessor : Subprocessor {
     override fun process(resolver: Resolver, codeGenerator: CodeGenerator, logger: KSPLogger) {
-        val collector = ArkiveComposableCollector(resolver, logger)
+        val arkiveComposableCollector = ArkiveComposableCollector(resolver, logger)
+        val previewCollector = PreviewCollector(resolver, logger)
         val validator = ComposeValidator(logger)
 
-        with(validator.validate(collector.collect())) {
+        val composeHolders = buildSet {
+            addAll(arkiveComposableCollector.collect())
+            addAll(previewCollector.collect())
+        }
+
+        with(validator.validate(composeHolders)) {
             ComposeSpec(codeGenerator, this, logger).write()
             ComposeMetaDataSpec(codeGenerator, this).write()
         }

--- a/processor/src/main/java/com/infinum/arkive/processor/subprocessors/ComposeSubprocessor.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/subprocessors/ComposeSubprocessor.kt
@@ -5,20 +5,30 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.infinum.arkive.processor.collectors.ArkiveComposableCollector
 import com.infinum.arkive.processor.collectors.PreviewCollector
+import com.infinum.arkive.processor.models.ArkiveOptions
 import com.infinum.arkive.processor.specs.ComposeMetaDataSpec
 import com.infinum.arkive.processor.specs.ComposeSpec
 import com.infinum.arkive.processor.validators.ComposeValidator
 
 class ComposeSubprocessor : Subprocessor {
-    override fun process(resolver: Resolver, codeGenerator: CodeGenerator, logger: KSPLogger) {
+    override fun process(
+        resolver: Resolver,
+        codeGenerator: CodeGenerator,
+        logger: KSPLogger,
+        options: ArkiveOptions,
+    ) {
         val arkiveComposableCollector = ArkiveComposableCollector(resolver, logger)
         val previewCollector = PreviewCollector(resolver, logger)
         val validator = ComposeValidator(logger)
 
         val composeHolders = buildSet {
             addAll(arkiveComposableCollector.collect())
-            addAll(previewCollector.collect())
+            if (options.skipPreviews.not()) {
+                addAll(previewCollector.collect())
+            }
         }
+
+        logger.warn("Holders: $composeHolders")
 
         with(validator.validate(composeHolders)) {
             ComposeSpec(codeGenerator, this, logger).write()

--- a/processor/src/main/java/com/infinum/arkive/processor/subprocessors/ComposeSubprocessor.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/subprocessors/ComposeSubprocessor.kt
@@ -28,8 +28,6 @@ class ComposeSubprocessor : Subprocessor {
             }
         }
 
-        logger.warn("Holders: $composeHolders")
-
         with(validator.validate(composeHolders)) {
             ComposeSpec(codeGenerator, this, logger).write()
             ComposeMetaDataSpec(codeGenerator, this).write()

--- a/processor/src/main/java/com/infinum/arkive/processor/subprocessors/Subprocessor.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/subprocessors/Subprocessor.kt
@@ -3,7 +3,13 @@ package com.infinum.arkive.processor.subprocessors
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
+import com.infinum.arkive.processor.models.ArkiveOptions
 
 interface Subprocessor {
-    fun process(resolver: Resolver, codeGenerator: CodeGenerator, logger: KSPLogger)
+    fun process(
+        resolver: Resolver,
+        codeGenerator: CodeGenerator,
+        logger: KSPLogger,
+        options: ArkiveOptions
+    )
 }

--- a/processor/src/main/java/com/infinum/arkive/processor/subprocessors/Subprocessor.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/subprocessors/Subprocessor.kt
@@ -10,6 +10,6 @@ interface Subprocessor {
         resolver: Resolver,
         codeGenerator: CodeGenerator,
         logger: KSPLogger,
-        options: ArkiveOptions
+        options: ArkiveOptions,
     )
 }

--- a/processor/src/main/java/com/infinum/arkive/processor/validators/ComposeValidator.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/validators/ComposeValidator.kt
@@ -25,4 +25,7 @@ class ComposeValidator(
     override fun validate(elements: Set<ComposeHolder>) = elements.filter {
         it.skip.not() && it.parameters.isEmpty() && it.function.hasValidScope
     }.toSet()
+        .also {
+            logger.info("Validated composable to only ${it.size}")
+        }
 }

--- a/testprocessor/src/main/java/com/infinum/arkive/processor/ArkiveTestProcessor.kt
+++ b/testprocessor/src/main/java/com/infinum/arkive/processor/ArkiveTestProcessor.kt
@@ -83,7 +83,5 @@ class ArkiveTestProcessor(
 class ArkiveTestProcessorProvider : SymbolProcessorProvider {
     override fun create(
         environment: SymbolProcessorEnvironment,
-    ): SymbolProcessor {
-        return ArkiveTestProcessor(environment.codeGenerator, environment.logger)
-    }
+    ): SymbolProcessor = ArkiveTestProcessor(environment.codeGenerator, environment.logger)
 }


### PR DESCRIPTION
## Summary

This pull request expands support for preview functions in the KSP processor.  
Previously, only functions annotated with `@ArkiveComposable` were handled — now all `@Preview`-like annotations are also supported.

## Changes

### Type

- [x] **Feature**: This pull request introduces a new feature.

### Description

- Added support for collecting all functions annotated with `@Preview`, including custom annotations like `@PreviewLightDark`.
- Since KSP does not support inherited (meta) annotations, the workaround involves:
  - Scanning all functions annotated with `@Composable`.
  - Checking if they contain a direct `@Preview` annotation to extract metadata (e.g. `name`, `group`).
  - If not, look for annotations whose names start with `"Preview"`.
- Priority is given to `@ArkiveComposable`. If it is present, other previews are ignored as `@ArkiveComposable` provides more complete metadata.
- Introduced a new `ksp` option: `skipPreviews`  
  This allows users to skip preview processing entirely, if needed.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).
