### PR TITLE
Build-failing golden verification via verifyShowcase<Variant>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,11 @@ after republishing the same version.
   with `python3 -m http.server`; the JSON is fetched, so `file://` won't work)
 - Per-variant module task: `./gradlew :sample:generateShowcaseUatDebug`
 - Verify retained goldens: `./gradlew :sample:verifyShowcaseUatDebug` (needs
-  `snapshotRetention` BASE/ALL and previously recorded goldens)
+  `snapshotRetention` BASE/ALL and previously recorded goldens). The sample leaves
+  retention at the NONE default, so reproducing verification means temporarily setting
+  `snapshotRetention.set(SnapshotRetention.BASE)` in `sample/build.gradle.kts` and
+  recording first — CI does not exercise this path. Run it in its own invocation (a
+  guard fails the build when combined with check/build/test/record).
 - Central deploy: `./gradlew deployAll` (needs `SONATYPE_USERNAME`/`SONATYPE_PASS` env vars +
   signing keys in `~/.gradle/gradle.properties`), then the OSSRH staging API dance: GET
   `/manual/search/repositories?state=open`, POST `/manual/upload/repository/<key>`, then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ after republishing the same version.
   `./gradlew generateWebShowcase` → output at `build/generated/arkive/showcase/` (serve it
   with `python3 -m http.server`; the JSON is fetched, so `file://` won't work)
 - Per-variant module task: `./gradlew :sample:generateShowcaseUatDebug`
+- Verify retained goldens: `./gradlew :sample:verifyShowcaseUatDebug` (needs
+  `snapshotRetention` BASE/ALL and previously recorded goldens)
 - Central deploy: `./gradlew deployAll` (needs `SONATYPE_USERNAME`/`SONATYPE_PASS` env vars +
   signing keys in `~/.gradle/gradle.properties`), then the OSSRH staging API dance: GET
   `/manual/search/repositories?state=open`, POST `/manual/upload/repository/<key>`, then
@@ -91,9 +93,13 @@ Modules and how they compose at a consumer's build time:
   (`FontVariant`, `DensityVariant`, `LayoutDirectionVariant`); on the consumer's classpath.
 - **plugin** — applies Paparazzi by id (kept off the consumer's compile classpath), injects
   the runtime/KSP dependencies at `ArkiveVersion.current`, forwards extension flags
-  (`enablePreviewParameters`, `enableVariants`, `snapshotRetention`) as KSP args, and
-  registers tasks: per-variant `generateShowcase<Variant>` (depends on
-  `recordPaparazzi<Variant>`) and root `generateWebShowcase`. Applying the plugin to the
+  (`enablePreviewParameters`, `enableVariants`) as KSP args and `snapshotRetention` as the
+  `arkive.snapshot.retention` system property on the consumer's Test tasks (read at test
+  runtime, so changing retention never invalidates KSP codegen), and registers tasks:
+  per-variant `generateShowcase<Variant>` (depends on `recordPaparazzi<Variant>`),
+  per-variant `verifyShowcase<Variant>` (depends on `verifyPaparazzi<Variant>`, scopes the
+  test run to Arkive's generated test class via a `taskGraph.whenReady` filter, and fails
+  fast when retention is NONE), and root `generateWebShowcase`. Applying the plugin to the
   consumer's **root** project registers the aggregate task eagerly — required under
   `org.gradle.configureondemand`, where task-name resolution happens before
   `projectsEvaluated` callbacks fire.
@@ -117,10 +123,22 @@ designed for GitHub Pages (relative paths only). It fetches `arkive-showcase.jso
 resolves images as `<module>/images/<basename(snapshotPath)>`. No build step, no CDN, no
 bundled fonts (system stack; the Infinum brand fonts are licensed and must not be added).
 
-## Known deferred work
+## Golden verification (verifyShowcase)
 
-Build-failing `verifyPaparazzi` for retained goldens is intentionally deferred: the
-generated tests currently swallow failures for record resilience, so verify cannot fail on
-Arkive snapshots. The working design (gating on the `paparazzi.test.verify` system
-property, aggregate failure reporting, marker-aware teardown absorber) lives in PR #16
-history around commits `4054fad`/`261f83f`.
+The failure-swallowing that keeps recording resilient is **mode-aware**, keyed on the
+`paparazzi.test.verify` system property Paparazzi itself sets. Three cooperating layers:
+
+- The generated shooter (`ComposeRunnerSpec`) collects per-component `AssertionError`s in
+  verify mode and throws one aggregate error naming every mismatched component; other
+  `Throwable`s (render crashes) stay skip-logged in both modes — a preview that never
+  recorded has no golden, so verify must not fail on it.
+- The generated test (`ArkiveTestProcessor`) reads `arkive.snapshot.retention` and
+  self-skips verification the retention policy has no goldens for (everything under NONE,
+  the variants test under BASE) — this keeps a consumer's own plain `verifyPaparazzi` runs
+  green instead of failing on golden-less Arkive snapshots. The RuleChain absorber
+  swallows teardown re-throws only in record mode.
+- `verifyShowcase<Variant>` is the public entry point (see plugin bullet above).
+
+Verified end-to-end on the sample (BASE retention, 31 base goldens): corrupted golden →
+aggregate failure naming the component; missing golden → failure; retention NONE → plain
+`verifyPaparazzi` stays green even with goldens missing, `verifyShowcase` fails fast.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ goldens the retention policy kept (base under `BASE`, everything under `ALL`), a
 the build with an aggregate report naming every mismatched component. With
 `snapshotRetention = NONE` the task fails fast — there is nothing to verify.
 
+Run it in its **own Gradle invocation**: the scoping narrows the module's shared
+unit-test task to Arkive's generated class for the whole invocation, so it cannot be
+combined with `check`, `build`, `generateShowcase<Variant>`, or anything else that runs
+those tests — the build fails fast with an explanation if it is.
+
 Recording stays resilient either way: a preview that fails to render is logged and
 skipped, never breaking the build, and is likewise excluded from verification (it has no
 golden). Running plain `verifyPaparazzi<Variant>` yourself is also safe — Arkive's tests

--- a/README.md
+++ b/README.md
@@ -58,9 +58,21 @@ arkive {
   committing every font/density/layout-direction variant.
 - `ALL` — everything stays; consider Git LFS for the golden directory.
 
-Note: Arkive's generated snapshot tests currently prioritize resilient recording — a
-preview that fails is logged and skipped rather than failing the build. Build-failing
-`verifyPaparazzi` support for the retained goldens is planned for a future release.
+Verify the retained goldens with Arkive's own task:
+
+```
+./gradlew verifyShowcase<Variant>
+```
+
+It runs Paparazzi's verify scoped to Arkive's generated test class only, checks the
+goldens the retention policy kept (base under `BASE`, everything under `ALL`), and fails
+the build with an aggregate report naming every mismatched component. With
+`snapshotRetention = NONE` the task fails fast — there is nothing to verify.
+
+Recording stays resilient either way: a preview that fails to render is logged and
+skipped, never breaking the build, and is likewise excluded from verification (it has no
+golden). Running plain `verifyPaparazzi<Variant>` yourself is also safe — Arkive's tests
+only enforce goldens the retention policy retained.
 
 Arkive only ever touches snapshots recorded by its own generated test class — your own
 Paparazzi goldens in the same directory are ignored.

--- a/plugin/src/main/java/com/infinum/arkive/plugin/ArkivePlugin.kt
+++ b/plugin/src/main/java/com/infinum/arkive/plugin/ArkivePlugin.kt
@@ -11,8 +11,11 @@ import com.infinum.arkive.plugin.tasks.GenerateShowcaseTask.Companion.RECORDING_
 import com.infinum.arkive.plugin.tasks.GenerateWebShowcaseTask
 import com.infinum.arkive.plugin.utils.ArkiveVersion
 import com.infinum.arkive.plugin.utils.capFirst
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.process.CommandLineArgumentProvider
 
 class ArkivePlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -43,9 +46,25 @@ class ArkivePlugin : Plugin<Project> {
             addPlugins(this)
             addDependencies(this)
             addTestDependencies(this)
+            forwardRetentionToTests(this)
             addTasks(this)
 
             addRootTasks(rootProject)
+        }
+    }
+
+    private fun forwardRetentionToTests(project: Project) {
+        // The generated snapshot test reads retention at runtime to decide which verify
+        // guards apply (see ArkiveTestProcessor). A lazy argument provider defers reading
+        // the extension until the test JVM is forked, after the consumer's script ran.
+        project.tasks.withType(Test::class.java).configureEach { test ->
+            test.jvmArgumentProviders.add(
+                CommandLineArgumentProvider {
+                    val retention = project.extensions.findByType(ArkiveExtension::class.java)
+                        ?.snapshotRetention?.get() ?: SnapshotRetention.NONE
+                    listOf("-Darkive.snapshot.retention=${retention.name}")
+                },
+            )
         }
     }
 
@@ -180,6 +199,44 @@ class ArkivePlugin : Plugin<Project> {
                 task.setSource(projectDir)
             }
         }
+        addVerifyTaskWithVariant(project, variant)
+    }
+
+    /**
+     * `verifyShowcase<Variant>` is the public verify entry point: it runs Paparazzi's
+     * verify scoped to Arkive's generated test class only, so the consumer's own Paparazzi
+     * tests and goldens are never pulled into an Arkive verification (mirroring the
+     * boundary SnapshotsGrabber keeps on the golden directory).
+     */
+    private fun addVerifyTaskWithVariant(project: Project, variant: String) {
+        val verifyTaskName = "$VERIFY_SHOWCASE_TASK${variant.capFirst}"
+        project.tasks.register(verifyTaskName) { task ->
+            task.group = GenerateShowcaseTask.GROUP
+            task.description = "Verifies Arkive snapshots against the retained goldens"
+            if (variant.isEmpty()) {
+                task.dependsOn(VERIFYING_TASK)
+            } else {
+                task.dependsOn("$VERIFYING_TASK${variant.capFirst}")
+            }
+        }
+
+        project.gradle.taskGraph.whenReady { graph ->
+            val verifyTask = project.tasks.findByName(verifyTaskName)
+            if (verifyTask != null && graph.hasTask(verifyTask)) {
+                val retention = project.extensions.findByType(ArkiveExtension::class.java)
+                    ?.snapshotRetention?.get() ?: SnapshotRetention.NONE
+                if (retention == SnapshotRetention.NONE) {
+                    throw GradleException(
+                        "Arkive: $verifyTaskName has nothing to verify — snapshotRetention is NONE, " +
+                            "so no goldens are retained. Set arkive.snapshotRetention to BASE or ALL " +
+                            "and record goldens with ${GenerateShowcaseTask.NAME}${variant.capFirst} first.",
+                    )
+                }
+                val testTaskName = if (variant.isEmpty()) "test" else "test${variant.capFirst}UnitTest"
+                val testTask = project.tasks.findByName(testTaskName) as? Test
+                testTask?.filter?.includeTestsMatching(GENERATED_TEST_CLASS)
+            }
+        }
     }
 
     private fun addRootTasks(rootProject: Project) {
@@ -214,5 +271,8 @@ class ArkivePlugin : Plugin<Project> {
 
     companion object {
         private const val PLUGIN_ID = "com.infinum.arkive"
+        private const val VERIFY_SHOWCASE_TASK = "verifyShowcase"
+        private const val VERIFYING_TASK = "verifyPaparazzi"
+        private const val GENERATED_TEST_CLASS = "com.infinum.arkive.ArkiveSnapshotTestGenerator"
     }
 }

--- a/plugin/src/main/java/com/infinum/arkive/plugin/ArkivePlugin.kt
+++ b/plugin/src/main/java/com/infinum/arkive/plugin/ArkivePlugin.kt
@@ -10,12 +10,13 @@ import com.infinum.arkive.plugin.tasks.GenerateShowcaseTask
 import com.infinum.arkive.plugin.tasks.GenerateShowcaseTask.Companion.RECORDING_TASK
 import com.infinum.arkive.plugin.tasks.GenerateWebShowcaseTask
 import com.infinum.arkive.plugin.utils.ArkiveVersion
+import com.infinum.arkive.plugin.utils.RetentionArgumentProvider
 import com.infinum.arkive.plugin.utils.capFirst
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.tasks.testing.Test
-import org.gradle.process.CommandLineArgumentProvider
 
 class ArkivePlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -46,25 +47,21 @@ class ArkivePlugin : Plugin<Project> {
             addPlugins(this)
             addDependencies(this)
             addTestDependencies(this)
-            forwardRetentionToTests(this)
             addTasks(this)
 
             addRootTasks(rootProject)
         }
     }
 
-    private fun forwardRetentionToTests(project: Project) {
+    private fun forwardRetentionToTests(project: Project, extension: ArkiveExtension) {
         // The generated snapshot test reads retention at runtime to decide which verify
-        // guards apply (see ArkiveTestProcessor). A lazy argument provider defers reading
-        // the extension until the test JVM is forked, after the consumer's script ran.
+        // guards apply (see ArkiveTestProcessor). The Provider defers reading the value
+        // until the test's inputs are resolved — after the consumer's script ran — and the
+        // named provider class keeps the Test task configuration-cache safe and makes the
+        // forwarded value a tracked input (see RetentionArgumentProvider).
+        val retention = extension.snapshotRetention.map { it.name }
         project.tasks.withType(Test::class.java).configureEach { test ->
-            test.jvmArgumentProviders.add(
-                CommandLineArgumentProvider {
-                    val retention = project.extensions.findByType(ArkiveExtension::class.java)
-                        ?.snapshotRetention?.get() ?: SnapshotRetention.NONE
-                    listOf("-Darkive.snapshot.retention=${retention.name}")
-                },
-            )
+            test.jvmArgumentProviders.add(RetentionArgumentProvider(retention))
         }
     }
 
@@ -74,6 +71,9 @@ class ArkivePlugin : Plugin<Project> {
                 "arkive",
                 ArkiveExtension::class.java,
             )
+            // Wired here, not from apply(): the extension must exist first, and this block
+            // is the earliest point that's true regardless of the consumer's plugin order.
+            forwardRetentionToTests(project, extension)
 
             project.afterEvaluate {
                 val enablePreviewParameters = extension.enablePreviewParameters.get()
@@ -181,7 +181,7 @@ class ArkivePlugin : Plugin<Project> {
     private fun addTaskWithVariant(project: Project, variant: String) {
         with(project) {
             tasks.register(
-                "${GenerateShowcaseTask.NAME}${variant.capFirst}",
+                showcaseTaskName(variant),
                 GenerateShowcaseTask::class.java,
             ) { task ->
                 task.group = GenerateShowcaseTask.GROUP
@@ -189,8 +189,7 @@ class ArkivePlugin : Plugin<Project> {
                 task.variant = variant
                 val extension = project.extensions.findByType(ArkiveExtension::class.java)
                 task.designFileKey = extension?.designFileKey?.get().orEmpty()
-                task.snapshotRetention =
-                    (extension?.snapshotRetention?.get() ?: SnapshotRetention.NONE).name
+                task.snapshotRetention = snapshotRetentionOf(project).name
                 if (variant.isEmpty()) {
                     task.dependsOn(RECORDING_TASK)
                 } else {
@@ -199,8 +198,19 @@ class ArkivePlugin : Plugin<Project> {
                 task.setSource(projectDir)
             }
         }
-        addVerifyTaskWithVariant(project, variant)
+        // The generated test class only exists where kspTestDebug ran (see
+        // addDependencies), so a release-variant verify would only fail with an opaque
+        // "No tests found for given includes".
+        if (variant.isEmpty() || variant.endsWith("Debug") || variant == "debug") {
+            addVerifyTaskWithVariant(project, variant)
+        }
     }
+
+    private fun showcaseTaskName(variant: String) = "${GenerateShowcaseTask.NAME}${variant.capFirst}"
+
+    private fun snapshotRetentionOf(project: Project): SnapshotRetention =
+        project.extensions.findByType(ArkiveExtension::class.java)
+            ?.snapshotRetention?.get() ?: SnapshotRetention.NONE
 
     /**
      * `verifyShowcase<Variant>` is the public verify entry point: it runs Paparazzi's
@@ -223,19 +233,54 @@ class ArkivePlugin : Plugin<Project> {
         project.gradle.taskGraph.whenReady { graph ->
             val verifyTask = project.tasks.findByName(verifyTaskName)
             if (verifyTask != null && graph.hasTask(verifyTask)) {
-                val retention = project.extensions.findByType(ArkiveExtension::class.java)
-                    ?.snapshotRetention?.get() ?: SnapshotRetention.NONE
-                if (retention == SnapshotRetention.NONE) {
+                if (snapshotRetentionOf(project) == SnapshotRetention.NONE) {
                     throw GradleException(
                         "Arkive: $verifyTaskName has nothing to verify — snapshotRetention is NONE, " +
                             "so no goldens are retained. Set arkive.snapshotRetention to BASE or ALL " +
-                            "and record goldens with ${GenerateShowcaseTask.NAME}${variant.capFirst} first.",
+                            "and record goldens with ${showcaseTaskName(variant)} first.",
                     )
                 }
+                failOnConflictingTasks(project, graph, verifyTaskName, variant)
                 val testTaskName = if (variant.isEmpty()) "test" else "test${variant.capFirst}UnitTest"
                 val testTask = project.tasks.findByName(testTaskName) as? Test
                 testTask?.filter?.includeTestsMatching(GENERATED_TEST_CLASS)
             }
+        }
+    }
+
+    /**
+     * The verify filter narrows the consumer's SHARED unit-test task to Arkive's generated
+     * class for the whole invocation, and Paparazzi resolves record-vs-verify from
+     * properties on that same task. Any co-scheduled task that drives those tests (check,
+     * build) would silently run none of the consumer's own tests, and a co-scheduled
+     * record (generateShowcase / recordPaparazzi) fights verify over the mode — fail fast
+     * instead of silently misbehaving.
+     */
+    private fun failOnConflictingTasks(
+        project: Project,
+        graph: TaskExecutionGraph,
+        verifyTaskName: String,
+        variant: String,
+    ) {
+        // The variant's own unit-test task can't be listed here — it is always in the
+        // graph as verifyPaparazzi's dependency, so a direct request for it is
+        // indistinguishable. The aggregates below catch the common combinations.
+        val conflicting = listOfNotNull(
+            project.tasks.findByName("check"),
+            project.tasks.findByName("build"),
+            project.tasks.findByName("test"),
+            project.tasks.findByName(showcaseTaskName(variant)),
+            project.tasks.findByName("$RECORDING_TASK${variant.capFirst}"),
+        ).filter { graph.hasTask(it) }
+        if (conflicting.isNotEmpty()) {
+            throw GradleException(
+                "Arkive: $verifyTaskName cannot share an invocation with " +
+                    conflicting.joinToString { it.name } +
+                    " — the verify filter restricts the shared unit-test task to Arkive's " +
+                    "generated class (their tests would silently not run), and record and " +
+                    "verify flip the same Paparazzi mode. Run $verifyTaskName in its own " +
+                    "Gradle invocation.",
+            )
         }
     }
 
@@ -265,7 +310,7 @@ class ArkivePlugin : Plugin<Project> {
             .mapNotNull { module ->
                 val variant = module.extensions.findByType(ArkiveExtension::class.java)
                     ?.multiModuleVariant?.get().orEmpty()
-                module.tasks.findByName("${GenerateShowcaseTask.NAME}${variant.capFirst}")?.path
+                module.tasks.findByName(showcaseTaskName(variant))?.path
             }
     }
 

--- a/plugin/src/main/java/com/infinum/arkive/plugin/utils/RetentionArgumentProvider.kt
+++ b/plugin/src/main/java/com/infinum/arkive/plugin/utils/RetentionArgumentProvider.kt
@@ -1,0 +1,30 @@
+package com.infinum.arkive.plugin.utils
+
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.process.CommandLineArgumentProvider
+
+/**
+ * Forwards the retention policy to the test JVM, where the generated snapshot test reads
+ * it to decide which verify guards apply (`ArkiveTestProcessor` reads the same property
+ * name — the two must stay in sync).
+ *
+ * A named class holding a [Provider] rather than a lambda over `Project`: nothing here
+ * captures the project, so `Test` tasks stay serializable under the configuration cache,
+ * and `@get:Input` makes the forwarded value a tracked task input — flipping
+ * `snapshotRetention` re-runs the tests instead of leaving them UP-TO-DATE on the old
+ * policy.
+ */
+internal class RetentionArgumentProvider(
+    @get:Input
+    val retention: Provider<String>,
+) : CommandLineArgumentProvider {
+
+    override fun asArguments(): Iterable<String> =
+        listOf("-D$RETENTION_SYSTEM_PROPERTY=${retention.get()}")
+
+    companion object {
+        // Read by the generated test class; see ArkiveTestProcessor.retentionProperty().
+        const val RETENTION_SYSTEM_PROPERTY = "arkive.snapshot.retention"
+    }
+}

--- a/processor/src/main/java/com/infinum/arkive/processor/specs/ComposeRunnerSpec.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/specs/ComposeRunnerSpec.kt
@@ -5,12 +5,15 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.infinum.arkive.processor.models.ComposeHolder
 import com.infinum.arkive.processor.shared.Constants
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.ksp.writeTo
@@ -57,10 +60,26 @@ class ComposeRunnerSpec(
         )
         // Each component (base or its variants) is isolated: a preview that fails to render
         // logs and is dropped from the showcase instead of aborting the whole snapshot run.
+        // In verify mode Paparazzi signals a golden mismatch as an AssertionError from
+        // snapshot() — those are collected (not swallowed) so verification can fail with an
+        // aggregate report. Render crashes stay skip-logged in both modes: a preview that
+        // never recorded has no golden, so verify must not fail on it.
         return CodeBlock.builder().apply {
             beginControlFlow("try")
             addStatement("%M(runner)", functionRunner)
-            nextControlFlow("catch (e: %T)", ClassName("kotlin", "Throwable"))
+            nextControlFlow("catch (e: %T)", ClassName(KOTLIN_PACKAGE, "AssertionError"))
+            beginControlFlow("if ($IS_VERIFY_RUN_PROPERTY)")
+            addStatement(
+                "$VERIFY_FAILURES_PROPERTY += %S + e.message",
+                "${holder.functionId}$wrapperSuffix: ",
+            )
+            nextControlFlow("else")
+            addStatement(
+                "println(%S + e.message)",
+                "Arkive: skipping component ${holder.functionId}$wrapperSuffix, snapshot failed: ",
+            )
+            endControlFlow()
+            nextControlFlow("catch (e: %T)", ClassName(KOTLIN_PACKAGE, "Throwable"))
             addStatement(
                 "println(%S + e.message)",
                 "Arkive: skipping component ${holder.functionId}$wrapperSuffix, snapshot failed: ",
@@ -75,13 +94,14 @@ class ComposeRunnerSpec(
                 RUNNER_FUNCTION,
                 LambdaTypeName.get(
                     parameters = arrayOf(
-                        ClassName("kotlin", "String"),
+                        ClassName(KOTLIN_PACKAGE, "String"),
                         LambdaTypeName.get(returnType = UNIT)
                             .copy(annotations = listOf(getComposableAnnotation())),
                     ),
                     returnType = UNIT,
                 ),
             )
+            .addStatement("val $VERIFY_FAILURES_PROPERTY = mutableListOf<String>()")
             // CodeBlocks are added directly, never rendered to String and re-parsed:
             // addCode(String) treats '%' as format specifiers and bypasses MemberName
             // import handling.
@@ -90,10 +110,34 @@ class ComposeRunnerSpec(
                     .apply { holders.forEach { add(getRunnerFunction(it, wrapperSuffix)) } }
                     .build(),
             )
+            .addCode(getAggregateThrow())
             .build()
     }
 
+    private fun getAggregateThrow(): CodeBlock {
+        // Verification reports every mismatched component at once instead of failing on
+        // the first — a re-record fixes them all in one pass.
+        return CodeBlock.builder().apply {
+            beginControlFlow("if ($VERIFY_FAILURES_PROPERTY.isNotEmpty())")
+            addStatement(
+                "throw AssertionError(%S + $VERIFY_FAILURES_PROPERTY.size + %S + " +
+                    "$VERIFY_FAILURES_PROPERTY.joinToString(%S) { %S + it })",
+                "Arkive: snapshot verification failed for ",
+                " component(s):\n",
+                "\n",
+                "  - ",
+            )
+            endControlFlow()
+        }.build()
+    }
+
     private fun getArkiveClass(): TypeSpec.Builder = TypeSpec.classBuilder(SIMPLE_NAME)
+        .addProperty(
+            PropertySpec.builder(IS_VERIFY_RUN_PROPERTY, BOOLEAN)
+                .addModifiers(KModifier.PRIVATE)
+                .initializer("java.lang.Boolean.getBoolean(%S)", "paparazzi.test.verify")
+                .build(),
+        )
 
     private fun getComposableAnnotation(): AnnotationSpec {
         return AnnotationSpec.builder(ClassName.bestGuess(ANNOTATION_COMPOSABLE))
@@ -106,5 +150,8 @@ class ComposeRunnerSpec(
         private const val RUN_COMPOSABLE_TESTS_FUNCTION = "runComposableTests"
         private const val RUN_COMPOSABLE_VARIANT_TESTS_FUNCTION = "runComposableVariantTests"
         private const val RUNNER_FUNCTION = "runner"
+        private const val KOTLIN_PACKAGE = "kotlin"
+        private const val IS_VERIFY_RUN_PROPERTY = "isVerifyRun"
+        private const val VERIFY_FAILURES_PROPERTY = "verifyFailures"
     }
 }

--- a/processor/src/main/java/com/infinum/arkive/processor/specs/ComposeRunnerSpec.kt
+++ b/processor/src/main/java/com/infinum/arkive/processor/specs/ComposeRunnerSpec.kt
@@ -70,18 +70,18 @@ class ComposeRunnerSpec(
             nextControlFlow("catch (e: %T)", ClassName(KOTLIN_PACKAGE, "AssertionError"))
             beginControlFlow("if ($IS_VERIFY_RUN_PROPERTY)")
             addStatement(
-                "$VERIFY_FAILURES_PROPERTY += %S + e.message",
+                "$VERIFY_FAILURES_PROPERTY += %S + (e.message ?: e.toString())",
                 "${holder.functionId}$wrapperSuffix: ",
             )
             nextControlFlow("else")
             addStatement(
-                "println(%S + e.message)",
+                "println(%S + (e.message ?: e.toString()))",
                 "Arkive: skipping component ${holder.functionId}$wrapperSuffix, snapshot failed: ",
             )
             endControlFlow()
             nextControlFlow("catch (e: %T)", ClassName(KOTLIN_PACKAGE, "Throwable"))
             addStatement(
-                "println(%S + e.message)",
+                "println(%S + (e.message ?: e.toString()))",
                 "Arkive: skipping component ${holder.functionId}$wrapperSuffix, snapshot failed: ",
             )
             endControlFlow()
@@ -133,6 +133,8 @@ class ComposeRunnerSpec(
 
     private fun getArkiveClass(): TypeSpec.Builder = TypeSpec.classBuilder(SIMPLE_NAME)
         .addProperty(
+            // Paparazzi's own verify-mode property — the same literal is read in the
+            // generated test class (ArkiveTestProcessor); keep the two in sync.
             PropertySpec.builder(IS_VERIFY_RUN_PROPERTY, BOOLEAN)
                 .addModifiers(KModifier.PRIVATE)
                 .initializer("java.lang.Boolean.getBoolean(%S)", "paparazzi.test.verify")

--- a/testprocessor/src/main/java/com/infinum/arkive/processor/ArkiveTestProcessor.kt
+++ b/testprocessor/src/main/java/com/infinum/arkive/processor/ArkiveTestProcessor.kt
@@ -8,6 +8,7 @@ import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -46,11 +47,46 @@ class ArkiveTestProcessor(
     private fun generateTestClass(): TypeSpec {
         return TypeSpec.classBuilder(FILE_NAME)
             .addModifiers(KModifier.PUBLIC)
+            .addProperty(isVerifyRunProperty())
+            .addProperty(retentionProperty())
             .addProperty(paparazziProperty())
             .addProperty(ruleChainProperty())
-            .addFunction(composableTestFunction("testAllComposableFunctions", "runComposableTests"))
-            .addFunction(composableTestFunction("testAllComposableVariants", "runComposableVariantTests"))
+            .addFunction(
+                composableTestFunction(
+                    "testAllComposableFunctions",
+                    "runComposableTests",
+                    // Base goldens exist under BASE and ALL retention.
+                    verifySkipCondition = "$RETENTION_PROPERTY == \"NONE\"",
+                ),
+            )
+            .addFunction(
+                composableTestFunction(
+                    "testAllComposableVariants",
+                    "runComposableVariantTests",
+                    // Variant goldens only exist under ALL retention.
+                    verifySkipCondition = "$RETENTION_PROPERTY != \"ALL\"",
+                ),
+            )
             .addFunction(viewTestFunction())
+            .build()
+    }
+
+    // Paparazzi flips verify mode via this system property on the test JVM; the generated
+    // code keys off the same source of truth instead of a parallel flag.
+    private fun isVerifyRunProperty(): PropertySpec {
+        return PropertySpec.builder(IS_VERIFY_RUN_PROPERTY, BOOLEAN)
+            .addModifiers(KModifier.PRIVATE)
+            .initializer("java.lang.Boolean.getBoolean(%S)", "paparazzi.test.verify")
+            .build()
+    }
+
+    // Injected by the Arkive Gradle plugin so verify runs only enforce snapshots whose
+    // goldens the retention policy actually kept — a consumer's plain verifyPaparazzi with
+    // retention NONE must not fail on golden-less Arkive snapshots.
+    private fun retentionProperty(): PropertySpec {
+        return PropertySpec.builder(RETENTION_PROPERTY, ClassName("kotlin", "String"))
+            .addModifiers(KModifier.PRIVATE)
+            .initializer("System.getProperty(%S) ?: %S", "arkive.snapshot.retention", "NONE")
             .build()
     }
 
@@ -72,8 +108,9 @@ class ArkiveTestProcessor(
 
     private fun ruleChainProperty(): PropertySpec {
         // Paparazzi re-throws snapshot errors at rule teardown even when the test body
-        // swallowed them. The outer rule absorbs that, so one broken preview (already
-        // logged and skipped) never fails the snapshot test as a whole.
+        // swallowed them. In record mode the outer rule absorbs that, so one broken preview
+        // (already logged and skipped) never fails the snapshot run. In verify mode failures
+        // are the whole point — they propagate and fail the build.
         return PropertySpec.builder(
             "arkiveRule",
             ClassName("org.junit.rules", "RuleChain"),
@@ -93,6 +130,9 @@ class ArkiveTestProcessor(
                                     try {
                                         base.evaluate()
                                     } catch (e: Throwable) {
+                                        if ($IS_VERIFY_RUN_PROPERTY) {
+                                            throw e
+                                        }
                                         println("Arkive: snapshot session finished with errors: " + e.message)
                                     }
                                 }
@@ -107,11 +147,19 @@ class ArkiveTestProcessor(
 
     // Base and variant snapshots run as separate tests so golden testing can target just
     // the base set: ./gradlew verifyPaparazzi<Variant> --tests '*.testAllComposableFunctions'
-    private fun composableTestFunction(testName: String, shooterFunction: String): FunSpec {
+    private fun composableTestFunction(
+        testName: String,
+        shooterFunction: String,
+        verifySkipCondition: String,
+    ): FunSpec {
         return FunSpec.builder(testName)
             .addAnnotation(getTestAnnotation())
             .addCode(
                 """
+                if ($IS_VERIFY_RUN_PROPERTY && $verifySkipCondition) {
+                    println("Arkive: $testName has no retained goldens (snapshotRetention = " + $RETENTION_PROPERTY + "), nothing to verify")
+                    return
+                }
                 val shooter = ArkiveComposeShoot()
                 shooter.$shooterFunction { name, function ->
                     paparazzi.snapshot(name = name) {
@@ -131,6 +179,10 @@ class ArkiveTestProcessor(
             .addAnnotation(getTestAnnotation())
             .addCode(
                 """
+                if ($IS_VERIFY_RUN_PROPERTY && $RETENTION_PROPERTY == "NONE") {
+                    println("Arkive: testAllViewFunctions has no retained goldens (snapshotRetention = NONE), nothing to verify")
+                    return
+                }
                 val shooter = ArkiveViewShoot()
                 shooter.runViewTests { name, function ->
                     val viewId = function()
@@ -145,6 +197,11 @@ class ArkiveTestProcessor(
     }
 
     private fun getTestAnnotation() = ClassName("org.junit", "Test")
+
+    companion object {
+        private const val IS_VERIFY_RUN_PROPERTY = "isVerifyRun"
+        private const val RETENTION_PROPERTY = "snapshotRetention"
+    }
 }
 
 class ArkiveTestProcessorProvider : SymbolProcessorProvider {

--- a/testprocessor/src/main/java/com/infinum/arkive/processor/ArkiveTestProcessor.kt
+++ b/testprocessor/src/main/java/com/infinum/arkive/processor/ArkiveTestProcessor.kt
@@ -14,9 +14,12 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.writeTo
 
+// ArkivePlugin.GENERATED_TEST_CLASS hardcodes "$PACKAGE_NAME.$FILE_NAME" for the verify
+// test filter — keep the three in sync.
 private const val PACKAGE_NAME = "com.infinum.arkive"
 private const val FILE_NAME = "ArkiveSnapshotTestGenerator"
 
@@ -72,7 +75,8 @@ class ArkiveTestProcessor(
     }
 
     // Paparazzi flips verify mode via this system property on the test JVM; the generated
-    // code keys off the same source of truth instead of a parallel flag.
+    // code keys off the same source of truth instead of a parallel flag. The same literal
+    // is read in ComposeRunnerSpec's generated shooter — keep the two in sync.
     private fun isVerifyRunProperty(): PropertySpec {
         return PropertySpec.builder(IS_VERIFY_RUN_PROPERTY, BOOLEAN)
             .addModifiers(KModifier.PRIVATE)
@@ -80,11 +84,12 @@ class ArkiveTestProcessor(
             .build()
     }
 
-    // Injected by the Arkive Gradle plugin so verify runs only enforce snapshots whose
+    // Injected by the Arkive Gradle plugin (RetentionArgumentProvider in :plugin defines
+    // the property name — keep in sync) so verify runs only enforce snapshots whose
     // goldens the retention policy actually kept — a consumer's plain verifyPaparazzi with
     // retention NONE must not fail on golden-less Arkive snapshots.
     private fun retentionProperty(): PropertySpec {
-        return PropertySpec.builder(RETENTION_PROPERTY, ClassName("kotlin", "String"))
+        return PropertySpec.builder(RETENTION_PROPERTY, STRING)
             .addModifiers(KModifier.PRIVATE)
             .initializer("System.getProperty(%S) ?: %S", "arkive.snapshot.retention", "NONE")
             .build()
@@ -156,9 +161,15 @@ class ArkiveTestProcessor(
             .addAnnotation(getTestAnnotation())
             .addCode(
                 """
-                if ($IS_VERIFY_RUN_PROPERTY && $verifySkipCondition) {
-                    println("Arkive: $testName has no retained goldens (snapshotRetention = " + $RETENTION_PROPERTY + "), nothing to verify")
-                    return
+                if ($IS_VERIFY_RUN_PROPERTY) {
+                    // A typo'd or unreachable retention value must not silently verify nothing.
+                    require($RETENTION_PROPERTY in listOf("NONE", "BASE", "ALL")) {
+                        "Arkive: unrecognized snapshotRetention '" + $RETENTION_PROPERTY + "' — expected NONE, BASE, or ALL"
+                    }
+                    if ($verifySkipCondition) {
+                        println("Arkive: $testName has no retained goldens (snapshotRetention = " + $RETENTION_PROPERTY + "), nothing to verify")
+                        return
+                    }
                 }
                 val shooter = ArkiveComposeShoot()
                 shooter.$shooterFunction { name, function ->
@@ -179,9 +190,14 @@ class ArkiveTestProcessor(
             .addAnnotation(getTestAnnotation())
             .addCode(
                 """
-                if ($IS_VERIFY_RUN_PROPERTY && $RETENTION_PROPERTY == "NONE") {
-                    println("Arkive: testAllViewFunctions has no retained goldens (snapshotRetention = NONE), nothing to verify")
-                    return
+                if ($IS_VERIFY_RUN_PROPERTY) {
+                    require($RETENTION_PROPERTY in listOf("NONE", "BASE", "ALL")) {
+                        "Arkive: unrecognized snapshotRetention '" + $RETENTION_PROPERTY + "' — expected NONE, BASE, or ALL"
+                    }
+                    if ($RETENTION_PROPERTY == "NONE") {
+                        println("Arkive: testAllViewFunctions has no retained goldens (snapshotRetention = NONE), nothing to verify")
+                        return
+                    }
                 }
                 val shooter = ArkiveViewShoot()
                 shooter.runViewTests { name, function ->


### PR DESCRIPTION
## Summary

Lands the deferred verify work: retained goldens are now actually enforceable. The failure-swallowing that keeps recording resilient becomes mode-aware (keyed on the `paparazzi.test.verify` system property Paparazzi itself sets), and a new `verifyShowcase<Variant>` task is the public verification entry point.

## Changes

**Generated shooter (`processor`)** — in verify mode, per-component `AssertionError`s (Paparazzi's mismatch signal) are collected and re-thrown as one aggregate error naming every mismatched component, so a single re-record fixes them all. Render crashes stay skip-logged in both modes: a preview that never recorded has no golden, so verify must not fail on it.

**Generated test (`testprocessor`)** — reads `arkive.snapshot.retention` (forwarded by the plugin as a system property on the consumer's `Test` tasks) and self-skips verification the retention policy kept no goldens for: everything under `NONE`, the variants test under `BASE`. This keeps a consumer's own plain `verifyPaparazzi` runs green instead of failing on golden-less Arkive snapshots. The RuleChain absorber swallows Paparazzi's teardown re-throws only in record mode.

**Plugin** — registers `verifyShowcase<Variant>`: depends on `verifyPaparazzi<Variant>`, scopes the test run to Arkive's generated test class via a `taskGraph.whenReady` filter (a consumer's own Paparazzi tests and goldens are never pulled into an Arkive verification — mirroring the boundary `SnapshotsGrabber` keeps), and fails fast with guidance when retention is `NONE`. Retention is forwarded lazily via `CommandLineArgumentProvider`, so changing it never invalidates KSP codegen.

## Testing

Verified end-to-end on the sample with `snapshotRetention = BASE` (31 base goldens recorded, variants pruned):

- `verifyShowcaseUatDebug` green on matching goldens
- Corrupted golden → build fails with the aggregate report naming the component, including Paparazzi's delta image and accept command
- Missing golden → build fails (catches newly added components)
- Retention `NONE` → `verifyShowcase` fails fast at configuration time with a clear message
- Retention `NONE` + missing golden → plain `verifyPaparazziUatDebug` stays green (self-skip)

The sample is left at the default retention (`NONE`) — its goldens directory is gitignored, so exercising verify in CI would need that entry removed and goldens committed (follow-up decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)